### PR TITLE
Adapt to linux kernel 5+ API

### DIFF
--- a/Drivers/Linux/Development_Files/kernel/driver.c
+++ b/Drivers/Linux/Development_Files/kernel/driver.c
@@ -66,8 +66,8 @@ struct file_operations qusb_fops = {
     // By not specifying the .read and .write callbacks reads and writes
     // will be forwarded to the .aio_read and .aio_write methods with the
     // IOCBs marked as synchronous.
-    .aio_read = qusb_aio_read,
-    .aio_write = qusb_aio_write,
+    .read_iter = qusb_read_iter,
+    .write_iter = qusb_write_iter,
 #else
     .read = qusb_read,
     .write = qusb_write,

--- a/Drivers/Linux/Development_Files/kernel/driver.h
+++ b/Drivers/Linux/Development_Files/kernel/driver.h
@@ -25,9 +25,10 @@ History      :
  IN THE SOFTWARE.
 
 =============================================================================*/
-#include <asm/errno.h>
-#include <asm/io.h>
-#include <asm/uaccess.h>
+#include <linux/errno.h>
+#include <linux/io.h>
+#include <linux/uio.h>
+#include <linux/uaccess.h>
 #include <linux/fs.h>
 #include <linux/highmem.h>
 #include <linux/init.h>
@@ -184,9 +185,8 @@ extern void qusb_delete(struct kref *kref);
 extern ssize_t qusb_sync(struct file *filp, char __user *buf, size_t count, BOOL read, BOOL sendReadLength);
 
 #if IMPLEMENT_ASYNC
-extern ssize_t qusb_aio_read(struct kiocb *iocb, const struct iovec *vec, unsigned long count, loff_t pos);
-extern ssize_t qusb_aio_write(struct kiocb *iocb, const struct iovec *vec, unsigned long count, loff_t pos);
-extern int qusb_aio_cancel(struct kiocb *iocb, struct io_event *event);
+extern ssize_t qusb_read_iter(struct kiocb *, struct iov_iter *);
+extern ssize_t qusb_write_iter(struct kiocb *, struct iov_iter *);
 extern ssize_t qusb_async(struct kiocb *iocb, char __user *buf, size_t count, BOOL read);
 #else
 extern ssize_t qusb_read(struct file *filp, char __user *buf, size_t count, loff_t *pos);

--- a/Drivers/Linux/Development_Files/kernel/sg.c
+++ b/Drivers/Linux/Development_Files/kernel/sg.c
@@ -120,14 +120,14 @@ void qusb_sg_complete(struct urb *urb)
             }
 
             // Unlock the page
-            page_cache_release(req->pages[k]);
+            put_page(req->pages[k]);
         }
 
         // Signal that the operation has completed
         complete(&io->complete);
 
         // Complete the asynchronous request
-        aio_complete(req->iocb, io->status, req->io.bytes);
+        req->iocb->ki_complete(req->iocb, io->status, req->io.bytes);
         QUSB_PRINTK(("Asynchronous request complete (%i, %i, %p)\n", (int)io->status, (int)req->io.bytes, req->iocb));
         
         // Handle internal request serialization

--- a/Drivers/Linux/Installer_Files/Drivers/v2.15.2/driver.c
+++ b/Drivers/Linux/Installer_Files/Drivers/v2.15.2/driver.c
@@ -66,8 +66,8 @@ struct file_operations qusb_fops = {
     // By not specifying the .read and .write callbacks reads and writes
     // will be forwarded to the .aio_read and .aio_write methods with the
     // IOCBs marked as synchronous.
-    .aio_read = qusb_aio_read,
-    .aio_write = qusb_aio_write,
+    .read_iter = qusb_read_iter,
+    .write_iter = qusb_write_iter,
 #else
     .read = qusb_read,
     .write = qusb_write,

--- a/Drivers/Linux/Installer_Files/Drivers/v2.15.2/driver.h
+++ b/Drivers/Linux/Installer_Files/Drivers/v2.15.2/driver.h
@@ -25,9 +25,10 @@ History      :
  IN THE SOFTWARE.
 
 =============================================================================*/
-#include <asm/errno.h>
-#include <asm/io.h>
-#include <asm/uaccess.h>
+#include <linux/errno.h>
+#include <linux/io.h>
+#include <linux/uio.h>
+#include <linux/uaccess.h>
 #include <linux/fs.h>
 #include <linux/highmem.h>
 #include <linux/init.h>
@@ -184,9 +185,8 @@ extern void qusb_delete(struct kref *kref);
 extern ssize_t qusb_sync(struct file *filp, char __user *buf, size_t count, BOOL read, BOOL sendReadLength);
 
 #if IMPLEMENT_ASYNC
-extern ssize_t qusb_aio_read(struct kiocb *iocb, const struct iovec *vec, unsigned long count, loff_t pos);
-extern ssize_t qusb_aio_write(struct kiocb *iocb, const struct iovec *vec, unsigned long count, loff_t pos);
-extern int qusb_aio_cancel(struct kiocb *iocb, struct io_event *event);
+extern ssize_t qusb_read_iter(struct kiocb *, struct iov_iter *);
+extern ssize_t qusb_write_iter(struct kiocb *, struct iov_iter *);
 extern ssize_t qusb_async(struct kiocb *iocb, char __user *buf, size_t count, BOOL read);
 #else
 extern ssize_t qusb_read(struct file *filp, char __user *buf, size_t count, loff_t *pos);

--- a/Drivers/Linux/Installer_Files/Drivers/v2.15.2/ioctl.h
+++ b/Drivers/Linux/Installer_Files/Drivers/v2.15.2/ioctl.h
@@ -6,7 +6,7 @@
  Notes        : 
  History      : 
 
-  Copyright (c) 2020 Bitwise Systems, Inc.
+ Copyright (c) 2020 Bitwise Systems, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining 
  a copy of this software and associated documentation files (the "Software"), 

--- a/Drivers/Linux/Installer_Files/Drivers/v2.15.2/sg.c
+++ b/Drivers/Linux/Installer_Files/Drivers/v2.15.2/sg.c
@@ -120,14 +120,14 @@ void qusb_sg_complete(struct urb *urb)
             }
 
             // Unlock the page
-            page_cache_release(req->pages[k]);
+            put_page(req->pages[k]);
         }
 
         // Signal that the operation has completed
         complete(&io->complete);
 
         // Complete the asynchronous request
-        aio_complete(req->iocb, io->status, req->io.bytes);
+        req->iocb->ki_complete(req->iocb, io->status, req->io.bytes);
         QUSB_PRINTK(("Asynchronous request complete (%i, %i, %p)\n", (int)io->status, (int)req->io.bytes, req->iocb));
         
         // Handle internal request serialization


### PR DESCRIPTION
This was tested on kernel 5.0.0 and 5.3.0 and should also work on newer ones. It of course breaks compatibility with the 2.x linux kernels, for which the driver was originally written for.